### PR TITLE
Allow for non-strict version check (major+minor only)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,8 @@ jobs:
       env:
         - ANSIBLE_VERSION=2.5
       script:
-        - make test ANSIBLE_VERSION=${ANSIBLE_VERSION}
+        - make test ANSIBLE_VERSION=${ANSIBLE_VERSION} HELM_VERSION=2.12.4 ANSIBLE_ARGS="'-e helm_version_strict=yes -e helm_version=2.12.4'"
+        - make test ANSIBLE_VERSION=${ANSIBLE_VERSION} HELM_VERSION=2.12.5 ANSIBLE_ARGS="'-e helm_version_strict=no  -e helm_version=2.12.4'"
 
     # Job 1: Ansible latest
     - stage: test ansible
@@ -45,4 +46,5 @@ jobs:
       env:
         - ANSIBLE_VERSION=latest
       script:
-        - make test ANSIBLE_VERSION=${ANSIBLE_VERSION}
+        - make test ANSIBLE_VERSION=${ANSIBLE_VERSION} HELM_VERSION=2.12.4 ANSIBLE_ARGS="'-e helm_version_strict=yes -e helm_version=2.12.4'"
+        - make test ANSIBLE_VERSION=${ANSIBLE_VERSION} HELM_VERSION=2.12.5 ANSIBLE_ARGS="'-e helm_version_strict=no  -e helm_version=2.12.4'"

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@
 ### Variables
 ###
 ANSIBLE_VERSION=2.5
+HELM_VERSION=2.12.3
+ANSIBLE_ARGS=
 
 
 ###
@@ -15,8 +17,10 @@ help:
 
 test:
 	docker run --rm -it \
+		-e HELM_VERSION=$(HELM_VERSION) \
+		-e ANSIBLE_ARGS=$(ANSIBLE_ARGS) \
 		-v ${PWD}:/etc/ansible/roles/rolename \
-		--workdir /etc/ansible/roles/rolename/tests \
+		-w /etc/ansible/roles/rolename/tests \
 		flaconi/ansible:${ANSIBLE_VERSION} ./support/run-tests.sh
 
 lint:

--- a/README.md
+++ b/README.md
@@ -14,11 +14,12 @@ This role handles the creation and updates of Helm charts.
 
 Additional variables that can be used (either as `host_vars`/`group_vars` or via command line args):
 
-| Variable                     | Description              |
-|------------------------------|--------------------------|
-| `helm_version`               | Exact locally expected Helm version (defaults to: `2.12.3`) |
-| `helm_configuration_files`   | Directory where chart configuration files is stored |
-| `helm_charts`                | List of items which represent the release. <br />Release items have the following fields: `release`,`chart`,`chart_version`,`values_file_path`,`namespace` |
+| Variable                    | Type   | Description              |
+|-----------------------------|--------|--------------------------|
+| `helm_version`              | string | Locally expected Helm version (major+minor) (defaults to: `2.12.3`) |
+| `helm_version_strict`       | bool   | If True, check against major, minor and patch, otherwise only major and minor version (defaults to: `True`) |
+| `helm_configuration_files`  | dict   | Directory where chart configuration files is stored |
+| `helm_charts`               | list   | List of items which represent the release. <br />Release items have the following fields: `release`,`chart`,`chart_version`,`values_file_path`,`namespace` |
 
 ## Example Usage
 
@@ -29,7 +30,8 @@ Additional variables that can be used (either as `host_vars`/`group_vars` or via
   roles:
     - role: rolename
       vars:
-        helm_version: 2.12.3
+        helm_version: 2.12.x
+        helm_version_strict: False
 
         # Directory with custom values for helm charts
         # Example:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,10 @@
 
 helm_version: 2.12.3
 
+# If set to true, check major, minor and patch version
+# otherwise only check against major and minor
+helm_version_strict: True
+
 # Directory with custom values for helm charts
 # Example:
 #   $ tree ./helm-config

--- a/tasks/check-version-loose.yml
+++ b/tasks/check-version-loose.yml
@@ -9,9 +9,14 @@
 
 - name: Set desired Helm version
   set_fact:
-    _helm_desired_version: "{{ helm_version | regex_replace('^(?P<major>[0-9]+)\\.(?P<minor>[0-9]+)\\.(?P<patch>[0-9]+)', 'v\\g<major>.\\g<minor>') }}"
+    _helm_desired_version: "{{
+      helm_version |
+      regex_replace('^(?P<major>[0-9]+)\\.(?P<minor>[0-9]+)\\.(?P<patch>[0-9]+)', 'v\\g<major>.\\g<minor>')
+    }}"
 
 - name: Fail if Helm version does NOT match (major and minor)
   fail:
-    msg: "Local Helm version does NOT match the requirements ({{ _helm_local_version.stdout }}). Please install Helm v{{ _helm_desired_version }}.x"
+    msg:
+      Local Helm version does NOT match the requirements ({{ _helm_local_version.stdout }}).
+      Please install Helm v{{ _helm_desired_version }}.x
   when: _helm_desired_version  != _helm_local_version.stdout

--- a/tasks/check-version-loose.yml
+++ b/tasks/check-version-loose.yml
@@ -17,6 +17,6 @@
 - name: Fail if Helm version does NOT match (major and minor)
   fail:
     msg:
-      Local Helm version does NOT match the requirements ({{ _helm_local_version.stdout }}).
+      Local Helm version ({{ _helm_local_version.stdout }}) does NOT match the requirements.
       Please install Helm v{{ _helm_desired_version }}.x
   when: _helm_desired_version  != _helm_local_version.stdout

--- a/tasks/check-version-loose.yml
+++ b/tasks/check-version-loose.yml
@@ -1,0 +1,17 @@
+---
+
+- name: Set installed Helm version
+  shell: "helm version --client --template '{{ '{{' }} .Client.SemVer {{ '}}' }}' | grep -Eo '^v[0-9]+\\.[0-9]+'"
+  register: _helm_local_version
+  changed_when: False
+  ignore_errors: True
+  check_mode: False
+
+- name: Set desired Helm version
+  set_fact:
+    _helm_desired_version: "{{ helm_version | regex_replace('^(?P<major>[0-9]+)\\.(?P<minor>[0-9]+)\\.(?P<patch>[0-9]+)', 'v\\g<major>.\\g<minor>') }}"
+
+- name: Fail if Helm version does NOT match (major and minor)
+  fail:
+    msg: "Local Helm version does NOT match the requirements ({{ _helm_local_version.stdout }}). Please install Helm v{{ _helm_desired_version }}.x"
+  when: _helm_desired_version  != _helm_local_version.stdout

--- a/tasks/check-version-strict.yml
+++ b/tasks/check-version-strict.yml
@@ -9,5 +9,7 @@
 
 - name: Fail if Helm version does NOT match exactly (major, minor and patch)
   fail:
-    msg: "Local Helm version does NOT match the requirements ({{ _helm_local_version.stdout }}). Please install Helm v{{ helm_version }}"
+    msg:
+      Local Helm version does NOT match the requirements ({{ _helm_local_version.stdout }}).
+      Please install Helm v{{ helm_version }}
   when: ('v' + helm_version) != _helm_local_version.stdout

--- a/tasks/check-version-strict.yml
+++ b/tasks/check-version-strict.yml
@@ -10,6 +10,6 @@
 - name: Fail if Helm version does NOT match exactly (major, minor and patch)
   fail:
     msg:
-      Local Helm version does NOT match the requirements ({{ _helm_local_version.stdout }}).
+      Local Helm version ({{ _helm_local_version.stdout }}) does NOT match the requirements.
       Please install Helm v{{ helm_version }}
   when: ('v' + helm_version) != _helm_local_version.stdout

--- a/tasks/check-version-strict.yml
+++ b/tasks/check-version-strict.yml
@@ -1,0 +1,13 @@
+---
+
+- name: Set installed Helm version
+  command: "helm version --client --template '{{ '{{' }} .Client.SemVer {{ '}}' }}'"
+  register: _helm_local_version
+  changed_when: False
+  ignore_errors: True
+  check_mode: False
+
+- name: Fail if Helm version does NOT match exactly (major, minor and patch)
+  fail:
+    msg: "Local Helm version does NOT match the requirements ({{ _helm_local_version.stdout }}). Please install Helm v{{ helm_version }}"
+  when: ('v' + helm_version) != _helm_local_version.stdout

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,9 +1,8 @@
 ---
 
 ###
-### Main entrypoint
+### Ensure Helm is installed
 ###
-
 - name: Check if Helm binary exists
   shell: command -v helm >/dev/null 2>&1
   register: _helm_exist
@@ -16,54 +15,20 @@
     msg: "Helm command doesn NOT exist. Please install Helm v{{ helm_version }}"
   when: _helm_exist.rc != 0
 
-- name: Get Helm version
-  command: "helm version --client --template '{{ '{{' }} .Client.SemVer {{ '}}' }}'"
-  register: _helm_local_version
-  changed_when: False
-  ignore_errors: True
-  check_mode: False
 
-- name: Fail if Helm version does NOT match
-  fail:
-    msg: "Local Helm version does NOT match the requirements. Please install Helm v{{ helm_version }}"
-  when: ('v' + helm_version) != _helm_local_version.stdout
+###
+### Ensure local Helm version is correct
+###
+- include_tasks: check-version-strict.yml
+  when:
+    - helm_version_strict == True
 
-- name: Update tiller
-  command: "helm init --upgrade"
+- include_tasks: check-version-loose.yml
+  when:
+    - helm_version_strict == False
 
-- name: Get the latest list of charts
-  command: "helm repo update"
 
-- name: Get all Helm releases
-  command: "helm list --all --output yaml"
-  register: _get_releases_command
-  check_mode: False
-
-- name: Parse all Helm releases
-  set_fact:
-    # Resource: https://stackoverflow.com/a/39852380
-    helm_raw_releases: "{{ _get_releases_command.stdout | from_yaml }}"
-
-- name: Get array of release names
-  set_fact:
-    helm_release_names: "{{ helm_raw_releases.Releases | map(attribute='Name') | list }}"
-
-- name: Install chart (if release does NOT exist yet)
-  command: |
-    helm install {{ item.chart }}
-      --version {{ item.chart_version }}
-      --namespace {{ item.namespace }}
-      --values {{ helm_configuration_files }}/{{ item.values_file_path }}
-      --name {{ item.release }}
-  with_items: "{{ helm_charts }}"
-  when: item.release not in helm_release_names
-
-- name: Update chart (if release exist already)
-  command: |
-    helm upgrade
-      --version {{ item.chart_version }}
-      --namespace {{ item.namespace }}
-      --values {{ helm_configuration_files }}/{{ item.values_file_path }}
-      {{ item.release }} {{ item.chart }}
-  with_items: "{{ helm_charts }}"
-  when: item.release in helm_release_names
+###
+### Run
+###
+- include_tasks: run.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,11 +21,11 @@
 ###
 - include_tasks: check-version-strict.yml
   when:
-    - helm_version_strict == True
+    - helm_version_strict|bool == True
 
 - include_tasks: check-version-loose.yml
   when:
-    - helm_version_strict == False
+    - helm_version_strict|bool == False
 
 
 ###

--- a/tasks/run.yml
+++ b/tasks/run.yml
@@ -19,7 +19,12 @@
 
 - name: Get array of release names
   set_fact:
-    helm_release_names: "{% if 'Releases' in helm_raw_releases %}{{ helm_raw_releases.Releases | map(attribute='Name') | list }}{% else %}{{ [] }}{% endif %}"
+    helm_release_names: >-
+      {%- if 'Releases' in helm_raw_releases -%}
+      {{ helm_raw_releases.Releases | map(attribute='Name') | list }}
+      {%- else -%}
+      {{ [] }}
+      {%- endif %}"
 
 - name: Install chart (if release does NOT exist yet)
   command: |

--- a/tasks/run.yml
+++ b/tasks/run.yml
@@ -19,7 +19,7 @@
 
 - name: Get array of release names
   set_fact:
-    helm_release_names: "{{ helm_raw_releases.Releases | map(attribute='Name') | list }}"
+    helm_release_names: "{% if 'Releases' in helm_raw_releases %}{{ helm_raw_releases.Releases | map(attribute='Name') | list }}{% else %}{{ [] }}{% endif %}"
 
 - name: Install chart (if release does NOT exist yet)
   command: |

--- a/tasks/run.yml
+++ b/tasks/run.yml
@@ -1,0 +1,42 @@
+---
+
+- name: Update tiller
+  command: "helm init --upgrade"
+
+- name: Get the latest list of charts
+  command: "helm repo update"
+  check_mode: False
+
+- name: Get all Helm releases
+  command: "helm list --all --output yaml"
+  register: _get_releases_command
+  check_mode: False
+
+- name: Parse all Helm releases
+  set_fact:
+    # Resource: https://stackoverflow.com/a/39852380
+    helm_raw_releases: "{{ _get_releases_command.stdout | from_yaml }}"
+
+- name: Get array of release names
+  set_fact:
+    helm_release_names: "{{ helm_raw_releases.Releases | map(attribute='Name') | list }}"
+
+- name: Install chart (if release does NOT exist yet)
+  command: |
+    helm install {{ item.chart }}
+      --version {{ item.chart_version }}
+      --namespace {{ item.namespace }}
+      --values {{ helm_configuration_files }}/{{ item.values_file_path }}
+      --name {{ item.release }}
+  with_items: "{{ helm_charts }}"
+  when: item.release not in helm_release_names
+
+- name: Update chart (if release exist already)
+  command: |
+    helm upgrade
+      --version {{ item.chart_version }}
+      --namespace {{ item.namespace }}
+      --values {{ helm_configuration_files }}/{{ item.values_file_path }}
+      {{ item.release }} {{ item.chart }}
+  with_items: "{{ helm_charts }}"
+  when: item.release in helm_release_names

--- a/tests/support/helm.mock
+++ b/tests/support/helm.mock
@@ -3,6 +3,15 @@
 # Mock Helm binary
 # If certain commands were called exit with successful code
 
+
+if env | grep -q '^HELM_VERSION=' 2>/dev/null; then
+	HELM_VERSION="$( env | grep '^HELM_VERSION=' | sed 's/^HELM_VERSION=//g' )"
+else
+	HELM_VERSION="2.12.3"
+fi
+
+
+
 arguments=$(printf "%s" "${*}")
 
 upgrade_prometheus_flags='upgrade --version 8.8.0 --namespace prometheus --values /etc/ansible/roles/rolename/tests/helm-config/prometheus/values.yml prometheus stable/prometheus'
@@ -10,7 +19,7 @@ install_logstash_flags='install stable/logstash --version 8.8.0 --namespace logs
 
 if [ "${arguments}" = "version --client --template '{{ .Client.SemVer }}'" ] || \
   [ "${arguments}" = "version --client --template {{ .Client.SemVer }}" ]; then
-  echo 'v2.12.3'
+  echo "v${HELM_VERSION}"
 elif [ "${arguments}" = 'init --upgrade' ]; then
   exit 0
 elif [ "${arguments}" = 'repo update' ]; then

--- a/tests/support/helm.mock
+++ b/tests/support/helm.mock
@@ -4,12 +4,7 @@
 # If certain commands were called exit with successful code
 
 
-if env | grep -q '^HELM_VERSION=' 2>/dev/null; then
-	HELM_VERSION="$( env | grep '^HELM_VERSION=' | sed 's/^HELM_VERSION=//g' )"
-else
-	HELM_VERSION="2.12.3"
-fi
-
+HELM_VERSION="${HELM_VERSION:-2.12.3}"
 
 
 arguments=$(printf "%s" "${*}")

--- a/tests/support/run-tests.sh
+++ b/tests/support/run-tests.sh
@@ -8,52 +8,65 @@ script_directory="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 test_directory="${script_directory}/.."
 
 
-# --- Test if role fails when Helm command does NOT exist ---
-set +e
-# Test if helm was installed successfully
-ansible-playbook "${test_directory}/test-defaults.yml"
+if env | grep -q '^HELM_VERSION=' 2>/dev/null; then
+	HELM_VERSION="$( env | grep '^HELM_VERSION=' | sed 's/^HELM_VERSION=//g' )"
+else
+	HELM_VERSION="2.12.3"
+fi
 
-exit_code=$?
-if [ "${exit_code}" = '0' ]; then
+if env | grep -q '^ANSIBLE_ARGS=' 2>/dev/null; then
+	ANSIBLE_ARGS="--diff $( env | grep '^ANSIBLE_ARGS=' | sed 's/^ANSIBLE_ARGS=//g' )"
+else
+	ANSIBLE_ARGS="--diff"
+fi
+
+
+echo "${ANSIBLE_ARGS}"
+echo
+echo "----------------------------------------------------------------------------------------------------"
+echo "- [NEED TO FAIL] Helm is not installed"
+echo "----------------------------------------------------------------------------------------------------"
+# --- Test if role fails when Helm command does NOT exist ---
+# Test if helm was installed successfully
+if ansible-playbook ${ANSIBLE_ARGS} ${test_directory}/test-defaults.yml; then
   echo "Role should fail since helm command does NOT exist"
   exit 1
 fi
-set -e
-# ---
 
 
+echo
+echo "----------------------------------------------------------------------------------------------------"
+echo "- [NEED TO FAIL] Helm has wrong version"
+echo "----------------------------------------------------------------------------------------------------"
 # --- Test if role fails when specific Helm version does NOT exist ---
 # Mock Helm
 echo -e "#!/usr/bin/env bash" > /usr/local/bin/helm
-echo -e "echo '2.12.3-wrong-version'" >> /usr/local/bin/helm
+echo -e "echo '1-wrong-version'" >> /usr/local/bin/helm
 chmod u+x /usr/local/bin/helm
 
-set +e
 # Test if helm was installed successfully
-ansible-playbook "${test_directory}/test-defaults.yml"
-
-exit_code=$?
-if [ "${exit_code}" = '0' ]; then
-  echo "Role should fail since helm command does NOT exist"
+if ansible-playbook ${ANSIBLE_ARGS} ${test_directory}/test-defaults.yml; then
+  echo "Role should fail since helm command has wrong version"
   exit 1
 fi
-set -e
-# ---
 
 
-# --- Test if role works if no charts were defined ---
 # Mock Helm
 cp "${script_directory}/helm.mock" /usr/local/bin/helm
 
-# Run the role
-ansible-playbook "${test_directory}/test-defaults.yml"
-# ---
+
+echo
+echo "----------------------------------------------------------------------------------------------------"
+echo "- [NEED TO SUCC] Role without charts defined"
+echo "----------------------------------------------------------------------------------------------------"
+ansible-playbook ${ANSIBLE_ARGS} ${test_directory}/test-defaults.yml
 
 
-# --- Test if role works with charts ---
-# Run the role
-ansible-playbook "${test_directory}/test-with-charts.yml"
-# ---
+echo
+echo "----------------------------------------------------------------------------------------------------"
+echo "- [NEED TO SUCC] Role with charts defined"
+echo "----------------------------------------------------------------------------------------------------"
+ansible-playbook ${ANSIBLE_ARGS} ${test_directory}/test-with-charts.yml
 
 
 # Clean up

--- a/tests/support/run-tests.sh
+++ b/tests/support/run-tests.sh
@@ -8,20 +8,14 @@ script_directory="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 test_directory="${script_directory}/.."
 
 
-if env | grep -q '^HELM_VERSION=' 2>/dev/null; then
-	HELM_VERSION="$( env | grep '^HELM_VERSION=' | sed 's/^HELM_VERSION=//g' )"
-else
-	HELM_VERSION="2.12.3"
-fi
-
-if env | grep -q '^ANSIBLE_ARGS=' 2>/dev/null; then
-	ANSIBLE_ARGS="--diff $( env | grep '^ANSIBLE_ARGS=' | sed 's/^ANSIBLE_ARGS=//g' )"
-else
-	ANSIBLE_ARGS="--diff"
-fi
+HELM_VERSION="${HELM_VERSION:-2.12.3}"
+ANSIBLE_ARGS="--diff ${ANSIBLE_ARGS:-}"
 
 
-echo "${ANSIBLE_ARGS}"
+
+echo "Ansible arguments set to '${ANSIBLE_ARGS}'. Overwrite with ANSIBLE_ARGS"
+
+
 echo
 echo "----------------------------------------------------------------------------------------------------"
 echo "- [NEED TO FAIL] Helm is not installed"


### PR DESCRIPTION
# Allow for non-strict version check

## Description

This is a backwards compatible PR which adds the option to also check against major and minor version of locally installed Helm binary only.

The default stays to check against major, minor and patch and can be changed by turning `helm_version_strict` to `False`

Additionally it improves Ansible dry-run (`--check`) mode.

For better readability `tasks/main.yml` has been split into multiple files

## Tagging

Next git tag will be `v0.2.0` as this is a feature update

## To clarify

@czerasz-flaconi 
What I am currently not sure about is: How does this role know to which K8s cluster to connect to. I don't seem to find any settings there... Is it just relying on the right kubectl context currently set?