### PR TITLE
Initialize Helm locally only

### DIFF
--- a/tasks/run.yml
+++ b/tasks/run.yml
@@ -25,7 +25,7 @@
       {{ helm_raw_releases.Releases | map(attribute='Name') | list }}
       {%- else -%}
       {{ [] }}
-      {%- endif %}"
+      {%- endif %}
 
 - name: Install chart (if release does NOT exist yet)
   command: |

--- a/tasks/run.yml
+++ b/tasks/run.yml
@@ -27,7 +27,7 @@
       {{ [] }}
       {%- endif %}
 
-- name: "Install chart: {{ item.chart }}"
+- name: Install chart (if release does NOT exist yet)
   command: |
     helm install {{ item.chart }}
       --version {{ item.chart_version }}
@@ -37,7 +37,7 @@
   with_items: "{{ helm_charts }}"
   when: item.release not in helm_release_names
 
-- name: "Update chart: {{ item.chart }}"
+- name: Update chart (if release exist already)
   command: |
     helm upgrade
       --version {{ item.chart_version }}

--- a/tasks/run.yml
+++ b/tasks/run.yml
@@ -1,7 +1,8 @@
 ---
 
 - name: Update tiller
-  command: "helm init --upgrade"
+  command: "helm init --client-only"
+  check_mode: False
 
 - name: Get the latest list of charts
   command: "helm repo update"

--- a/tasks/run.yml
+++ b/tasks/run.yml
@@ -3,15 +3,18 @@
 - name: Update tiller
   command: "helm init --client-only"
   check_mode: False
+  changed_when: False
 
 - name: Get the latest list of charts
   command: "helm repo update"
   check_mode: False
+  changed_when: False
 
 - name: Get all Helm releases
   command: "helm list --all --output yaml"
   register: _get_releases_command
   check_mode: False
+  changed_when: False
 
 - name: Parse all Helm releases
   set_fact:

--- a/tasks/run.yml
+++ b/tasks/run.yml
@@ -27,7 +27,7 @@
       {{ [] }}
       {%- endif %}
 
-- name: Install chart (if release does NOT exist yet)
+- name: "Install chart: {{ item.chart }}"
   command: |
     helm install {{ item.chart }}
       --version {{ item.chart_version }}
@@ -37,7 +37,7 @@
   with_items: "{{ helm_charts }}"
   when: item.release not in helm_release_names
 
-- name: Update chart (if release exist already)
+- name: "Update chart: {{ item.chart }}"
   command: |
     helm upgrade
       --version {{ item.chart_version }}

--- a/tests/support/helm.mock
+++ b/tests/support/helm.mock
@@ -17,6 +17,8 @@ if [ "${arguments}" = "version --client --template '{{ .Client.SemVer }}'" ] || 
   echo "v${HELM_VERSION}"
 elif [ "${arguments}" = 'init --upgrade' ]; then
   exit 0
+elif [ "${arguments}" = 'init --client-only' ]; then
+  exit 0
 elif [ "${arguments}" = 'repo update' ]; then
   exit 0
 elif [ "${arguments}" = 'list --all --output yaml' ]; then


### PR DESCRIPTION
# Initialize Helm locally only

This PR removes `helm init --upgrade` to prevent a role, which should only install helm charts, from updating a tiller deployment on K8s.

Additionally the local init will always be run, even in checkmode to make this role fully checkmode capable.

#### Tagging

Next tag will be `v0.2.1`