### PR TITLE
OPS-0 Allow to specify kubectl context for Helm

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Additional variables that can be used (either as `host_vars`/`group_vars` or via
 |-----------------------------|--------|--------------------------|
 | `helm_version`              | string | Locally expected Helm version (major+minor) (defaults to: `2.12.3`) |
 | `helm_version_strict`       | bool   | If True, check against major, minor and patch, otherwise only major and minor version (defaults to: `True`) |
+| `helm_kubectl_context`      | string | If specified, use this kubectl context, otherwise it will use the currently selected default context |
 | `helm_configuration_files`  | dict   | Directory where chart configuration files is stored |
 | `helm_charts`               | list   | List of items which represent the release. <br />Release items have the following fields: `release`,`chart`,`chart_version`,`values_file_path`,`namespace` |
 
@@ -32,6 +33,7 @@ Additional variables that can be used (either as `host_vars`/`group_vars` or via
       vars:
         helm_version: 2.12.x
         helm_version_strict: False
+        helm_kubectl_context: minikube
 
         # Directory with custom values for helm charts
         # Example:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,6 +20,9 @@ helm_version_strict: True
 #       └── values.yml
 helm_configuration_files: "{{ playbook_dir }}/helm-config"
 
+# If set, it will use the specified kubectl context
+helm_kubectl_context:
+
 # List of Helm charts which will be installed/updated
 helm_charts: []
 # Example

--- a/tasks/run.yml
+++ b/tasks/run.yml
@@ -1,17 +1,32 @@
 ---
 
 - name: Update tiller
-  command: "helm init --client-only"
+  command: |
+    helm init
+      {% if helm_kubectl_context is defined and helm_kubectl_context %}
+      --kube-context {{ helm_kubectl_context }}
+      {% endif %}
+      --client-only
   check_mode: False
   changed_when: False
 
 - name: Get the latest list of charts
-  command: "helm repo update"
+  command: |
+    helm repo update
+      {% if helm_kubectl_context is defined and helm_kubectl_context %}
+      --kube-context {{ helm_kubectl_context }}
+      {% endif %}
   check_mode: False
   changed_when: False
 
 - name: Get all Helm releases
-  command: "helm list --all --output yaml"
+  command: |
+    helm list
+      {% if helm_kubectl_context is defined and helm_kubectl_context %}
+      --kube-context {{ helm_kubectl_context }}
+      {% endif %}
+      --all
+      --output yaml
   register: _get_releases_command
   check_mode: False
   changed_when: False
@@ -33,6 +48,9 @@
 - name: Install chart (if release does NOT exist yet)
   command: |
     helm install {{ item.chart }}
+      {% if helm_kubectl_context is defined and helm_kubectl_context %}
+      --kube-context {{ helm_kubectl_context }}
+      {% endif %}
       --version {{ item.chart_version }}
       --namespace {{ item.namespace }}
       --values {{ helm_configuration_files }}/{{ item.values_file_path }}
@@ -44,6 +62,9 @@
   command: |
     helm upgrade
       --version {{ item.chart_version }}
+      {% if helm_kubectl_context is defined and helm_kubectl_context %}
+      --kube-context {{ helm_kubectl_context }}
+      {% endif %}
       --namespace {{ item.namespace }}
       --values {{ helm_configuration_files }}/{{ item.values_file_path }}
       {{ item.release }} {{ item.chart }}

--- a/tasks/run.yml
+++ b/tasks/run.yml
@@ -61,10 +61,10 @@
 - name: Update chart (if release exist already)
   command: |
     helm upgrade
-      --version {{ item.chart_version }}
       {% if helm_kubectl_context is defined and helm_kubectl_context %}
       --kube-context {{ helm_kubectl_context }}
       {% endif %}
+      --version {{ item.chart_version }}
       --namespace {{ item.namespace }}
       --values {{ helm_configuration_files }}/{{ item.values_file_path }}
       {{ item.release }} {{ item.chart }}

--- a/tests/support/helm.mock
+++ b/tests/support/helm.mock
@@ -5,23 +5,28 @@
 
 
 HELM_VERSION="${HELM_VERSION:-2.12.3}"
+HELM_KUBECTL_CONTEXT="${HELM_KUBECTL_CONTEXT:-}"
+EXTRA_PARAMS=
 
+if [ -n "${HELM_KUBECTL_CONTEXT}" ]; then
+	EXTRA_PARAMS="--kube-context ${HELM_KUBECTL_CONTEXT} "
+fi
 
 arguments=$(printf "%s" "${*}")
 
-upgrade_prometheus_flags='upgrade --version 8.8.0 --namespace prometheus --values /etc/ansible/roles/rolename/tests/helm-config/prometheus/values.yml prometheus stable/prometheus'
-install_logstash_flags='install stable/logstash --version 8.8.0 --namespace logstash --values /etc/ansible/roles/rolename/tests/helm-config/logstash/values.yml --name logstash'
+upgrade_prometheus_flags="upgrade ${EXTRA_PARAMS}--version 8.8.0 --namespace prometheus --values /etc/ansible/roles/rolename/tests/helm-config/prometheus/values.yml prometheus stable/prometheus"
+install_logstash_flags="install stable/logstash ${EXTRA_PARAMS}--version 8.8.0 --namespace logstash --values /etc/ansible/roles/rolename/tests/helm-config/logstash/values.yml --name logstash"
 
 if [ "${arguments}" = "version --client --template '{{ .Client.SemVer }}'" ] || \
   [ "${arguments}" = "version --client --template {{ .Client.SemVer }}" ]; then
   echo "v${HELM_VERSION}"
-elif [ "${arguments}" = 'init --upgrade' ]; then
+elif [ "${arguments}" = "init ${EXTRA_PARAMS}--upgrade" ]; then
   exit 0
-elif [ "${arguments}" = 'init --client-only' ]; then
+elif [ "${arguments}" = "init ${EXTRA_PARAMS}--client-only" ]; then
   exit 0
-elif [ "${arguments}" = 'repo update' ]; then
+elif [ "${arguments} " = "repo update ${EXTRA_PARAMS}" ]; then
   exit 0
-elif [ "${arguments}" = 'list --all --output yaml' ]; then
+elif [ "${arguments}" = "list ${EXTRA_PARAMS}--all --output yaml" ]; then
   # helm list --all --output yaml
   cat << EOF
 Next: ""

--- a/tests/support/run-tests.sh
+++ b/tests/support/run-tests.sh
@@ -63,5 +63,20 @@ echo "--------------------------------------------------------------------------
 ansible-playbook ${ANSIBLE_ARGS} ${test_directory}/test-with-charts.yml
 
 
+echo
+echo "----------------------------------------------------------------------------------------------------"
+echo "- [NEED TO SUCC] (kubecontext) Role without charts defined"
+echo "----------------------------------------------------------------------------------------------------"
+export HELM_KUBECTL_CONTEXT=minikube
+ansible-playbook ${ANSIBLE_ARGS} ${test_directory}/test-defaults.yml -e helm_kubectl_context=${HELM_KUBECTL_CONTEXT}
+
+echo
+echo "----------------------------------------------------------------------------------------------------"
+echo "- [NEED TO SUCC] (kubecontext) Role with charts defined"
+echo "----------------------------------------------------------------------------------------------------"
+export HELM_KUBECTL_CONTEXT=minikube
+ansible-playbook ${ANSIBLE_ARGS} ${test_directory}/test-with-charts.yml -e helm_kubectl_context=${HELM_KUBECTL_CONTEXT}
+
+
 # Clean up
 rm -f /usr/local/bin/helm || true

--- a/tests/support/run-tests.sh
+++ b/tests/support/run-tests.sh
@@ -69,6 +69,7 @@ echo "- [NEED TO SUCC] (kubecontext) Role without charts defined"
 echo "----------------------------------------------------------------------------------------------------"
 export HELM_KUBECTL_CONTEXT=minikube
 ansible-playbook ${ANSIBLE_ARGS} ${test_directory}/test-defaults.yml -e helm_kubectl_context=${HELM_KUBECTL_CONTEXT}
+unset HELM_KUBECTL_CONTEXT
 
 echo
 echo "----------------------------------------------------------------------------------------------------"
@@ -76,6 +77,7 @@ echo "- [NEED TO SUCC] (kubecontext) Role with charts defined"
 echo "----------------------------------------------------------------------------------------------------"
 export HELM_KUBECTL_CONTEXT=minikube
 ansible-playbook ${ANSIBLE_ARGS} ${test_directory}/test-with-charts.yml -e helm_kubectl_context=${HELM_KUBECTL_CONTEXT}
+unset HELM_KUBECTL_CONTEXT
 
 
 # Clean up


### PR DESCRIPTION
# Allow to specify kubectl context for Helm

This PR introduces an optional Ansible variable: `helm_kubectl_context` which if set, will enforce the role to use the specified context instead of the currently selected one.

### Tagging

As this is a feature release, the next tag will be `v0.3.0`