### PR TITLE
Add templating feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ Additional variables that can be used (either as `host_vars`/`group_vars` or via
 | `helm_charts`               | list   | List of items which represent the release. <br />Release items have the following fields: `release`,`chart`,`chart_version`,`values_file_path`,`namespace` |
 | `helm_repositories`         | list   | List of items which represent the repository. <br />Repository items have the following fields: `name`,`url` |
 
+> ** NOTE **
+> <br />The `values_file_path` property of the items stored in `helm_charts` is treated as a Jinja2 template
+
 ## Example Usage
 
 ```yml
@@ -44,21 +47,21 @@ Additional variables that can be used (either as `host_vars`/`group_vars` or via
         #   $ tree ./helm-config
         #   ./helm-config
         #   ├── prometheus
-        #   │   └── values.yml
+        #   │   └── values.yml.j2
         #   └── logstash
-        #       └── values.yml
+        #       └── values.yml.j2
         helm_configuration_files: "{{ playbook_dir }}/helm-config"
         helm_charts:
           - release: prometheus
             chart: stable/prometheus
             chart_version: 8.8.0
-            values_file_path: prometheus/values.yml
+            values_file_path: prometheus/values.yml.j2
             namespace: prometheus
 
           - release: logstash
             chart: stable/logstash
             chart_version: 8.8.0
-            values_file_path: logstash/values.yml
+            values_file_path: logstash/values.yml.j2
             namespace: logstash
 ```
 

--- a/tasks/run-dry.yml
+++ b/tasks/run-dry.yml
@@ -2,17 +2,17 @@
 
 - name: Install chart (if release does NOT exist yet)
   command: |
-    helm install {{ item.chart }}
+    helm install {{ item.item.chart }}
       {% if helm_kubectl_context is defined and helm_kubectl_context %}
       --kube-context {{ helm_kubectl_context }}
       {% endif %}
       --dry-run
-      --version {{ item.chart_version }}
-      --namespace {{ item.namespace }}
-      --values {{ helm_configuration_files }}/{{ item.values_file_path }}
-      --name {{ item.release }}
+      --version {{ item.item.chart_version }}
+      --namespace {{ item.item.namespace }}
+      --values {{ item.path }}
+      --name {{ item.item.release }}
   with_items: "{{ helm_charts }}"
-  when: item.release not in helm_release_names
+  when: item.item.release not in helm_release_names
   register: _helm_install_chart
   check_mode: False
   changed_when: False
@@ -35,12 +35,12 @@
       --kube-context {{ helm_kubectl_context }}
       {% endif %}
       --dry-run
-      --version {{ item.chart_version }}
-      --namespace {{ item.namespace }}
-      --values {{ helm_configuration_files }}/{{ item.values_file_path }}
-      {{ item.release }} {{ item.chart }}
+      --version {{ item.item.chart_version }}
+      --namespace {{ item.item.namespace }}
+      --values {{ item.path }}
+      {{ item.item.release }} {{ item.item.chart }}
   with_items: "{{ helm_charts }}"
-  when: item.release in helm_release_names
+  when: item.item.release in helm_release_names
   register: _helm_upgrade_chart
   check_mode: False
   changed_when: False

--- a/tasks/run-normal.yml
+++ b/tasks/run-normal.yml
@@ -2,16 +2,16 @@
 
 - name: Install chart (if release does NOT exist yet)
   command: |
-    helm install {{ item.chart }}
+    helm install {{ item.item.chart }}
       {% if helm_kubectl_context is defined and helm_kubectl_context %}
       --kube-context {{ helm_kubectl_context }}
       {% endif %}
-      --version {{ item.chart_version }}
-      --namespace {{ item.namespace }}
-      --values {{ helm_configuration_files }}/{{ item.values_file_path }}
-      --name {{ item.release }}
+      --version {{ item.item.chart_version }}
+      --namespace {{ item.item.namespace }}
+      --values {{ item.path }}
+      --name {{ item.item.release }}
   with_items: "{{ helm_charts }}"
-  when: item.release not in helm_release_names
+  when: item.item.release not in helm_release_names
 
 - name: Update chart (if release exist already)
   command: |
@@ -19,9 +19,9 @@
       {% if helm_kubectl_context is defined and helm_kubectl_context %}
       --kube-context {{ helm_kubectl_context }}
       {% endif %}
-      --version {{ item.chart_version }}
-      --namespace {{ item.namespace }}
-      --values {{ helm_configuration_files }}/{{ item.values_file_path }}
-      {{ item.release }} {{ item.chart }}
+      --version {{ item.item.chart_version }}
+      --namespace {{ item.item.namespace }}
+      --values {{ item.path }}
+      {{ item.item.release }} {{ item.item.chart }}
   with_items: "{{ helm_charts }}"
-  when: item.release in helm_release_names
+  when: item.item.release in helm_release_names

--- a/tasks/run.yml
+++ b/tasks/run.yml
@@ -72,6 +72,22 @@
       {{ [] }}
       {%- endif %}
 
+- name: Create temporary files to store the rendered template
+  tempfile:
+    state: file
+  register: rendered_template
+  with_items: "{{ helm_charts }}"
+  check_mode: False
+  changed_when: False
+
+- template:
+    src: "{{ helm_configuration_files }}/{{ item.item.values_file_path }}"
+    dest: "{{ item.path }}"
+    mode: '0400'
+  with_items: "{{ rendered_template.results }}"
+  check_mode: False
+  changed_when: False
+
 ###
 ### Split between normal run and dry run
 ###

--- a/tasks/run.yml
+++ b/tasks/run.yml
@@ -80,7 +80,8 @@
   check_mode: False
   changed_when: False
 
-- template:
+- name: Render templates
+  template:
     src: "{{ helm_configuration_files }}/{{ item.item.values_file_path }}"
     dest: "{{ item.path }}"
     mode: '0400'

--- a/tasks/run.yml
+++ b/tasks/run.yml
@@ -93,8 +93,12 @@
 ###
 - include_tasks: run-normal.yml
   # Run without --check mode
+  vars:
+    helm_charts: "{{ rendered_template.results }}"
   when: ansible_check_mode == False
 
 - include_tasks: run-dry.yml
   # Run only in --check mode
+  vars:
+    helm_charts: "{{ rendered_template.results }}"
   when: ansible_check_mode == True

--- a/tests/support/helm.mock
+++ b/tests/support/helm.mock
@@ -27,6 +27,9 @@ upgrade_prometheus_flags_regex="^${upgrade_prometheus_flags_prefix}.+${upgrade_p
 install_logstash_flags_prefix="install stable/logstash ${EXTRA_PARAMS}--version 8.8.0 --namespace logstash --values *"
 install_logstash_flags_suffix=" --name logstash"
 install_logstash_flags_regex="^${install_logstash_flags_prefix}.+${install_logstash_flags_suffix}$"
+install_test_template_flags_prefix="install stable/test-template ${EXTRA_PARAMS}--version 8.8.0 --namespace test-template --values *"
+install_test_template_flags_suffix=" --name test-template"
+install_test_template_flags_regex="^${install_test_template_flags_prefix}.+${install_test_template_flags_suffix}$"
 
 if [ "${arguments}" = "version --client --template '{{ .Client.SemVer }}'" ] || \
   [ "${arguments}" = "version --client --template {{ .Client.SemVer }}" ]; then
@@ -67,6 +70,17 @@ elif [[ "${arguments}" =~ $upgrade_prometheus_flags_regex ]]; then
   exit 0
 elif [[ "${arguments}" =~ $install_logstash_flags_regex ]]; then
   exit 0
+elif [[ "${arguments}" =~ $install_test_template_flags_regex ]]; then
+  # Get the file which was generated from the template
+  file_path=$(echo "${arguments}" | sed 's/^.*--values //' | sed 's/ --name.*$//')
+  if [ 'templates are rendered' == "$(cat ${file_path})" ]; then
+    exit 0
+  else
+    echo "Template was not rendered correctly"
+    echo "File content (${file_path}): "
+    cat "${file_path}"
+    exit 1
+  fi
 else
   echo "${arguments}"
   exit 1

--- a/tests/support/helm.mock
+++ b/tests/support/helm.mock
@@ -21,8 +21,12 @@ fi
 
 arguments=$(printf "%s" "${*}")
 
-upgrade_prometheus_flags="upgrade ${EXTRA_PARAMS}--version 8.8.0 --namespace prometheus --values /etc/ansible/roles/rolename/tests/helm-config/prometheus/values.yml prometheus stable/prometheus"
-install_logstash_flags="install stable/logstash ${EXTRA_PARAMS}--version 8.8.0 --namespace logstash --values /etc/ansible/roles/rolename/tests/helm-config/logstash/values.yml --name logstash"
+upgrade_prometheus_flags_prefix="upgrade ${EXTRA_PARAMS}--version 8.8.0 --namespace prometheus --values *"
+upgrade_prometheus_flags_suffix=" prometheus stable/prometheus"
+upgrade_prometheus_flags_regex="^${upgrade_prometheus_flags_prefix}.+${upgrade_prometheus_flags_suffix}$"
+install_logstash_flags_prefix="install stable/logstash ${EXTRA_PARAMS}--version 8.8.0 --namespace logstash --values *"
+install_logstash_flags_suffix=" --name logstash"
+install_logstash_flags_regex="^${install_logstash_flags_prefix}.+${install_logstash_flags_suffix}$"
 
 if [ "${arguments}" = "version --client --template '{{ .Client.SemVer }}'" ] || \
   [ "${arguments}" = "version --client --template {{ .Client.SemVer }}" ]; then
@@ -59,9 +63,9 @@ Releases:
   Status: DEPLOYED
   Updated: Wed Mar 03 06:36:33 2018
 EOF
-elif [ "${arguments}" = "${upgrade_prometheus_flags}" ]; then
+elif [[ "${arguments}" =~ $upgrade_prometheus_flags_regex ]]; then
   exit 0
-elif [ "${arguments}" = "${install_logstash_flags}" ]; then
+elif [[ "${arguments}" =~ $install_logstash_flags_regex ]]; then
   exit 0
 else
   echo "${arguments}"

--- a/tests/support/run-tests.sh
+++ b/tests/support/run-tests.sh
@@ -13,9 +13,10 @@ ANSIBLE_ARGS="--diff ${ANSIBLE_ARGS:-}"
 
 
 # Prepare fake Helm value files
-mkdir -p ${test_directory}/helm-config/{prometheus,logstash}
+mkdir -p ${test_directory}/helm-config/{prometheus,logstash,test-template}
 touch ${test_directory}/helm-config/prometheus/values.yml
 touch ${test_directory}/helm-config/logstash/values.yml
+echo '{{ template_test_value }}' > ${test_directory}/helm-config/test-template/values.yml.j2
 
 
 echo "Ansible arguments set to '${ANSIBLE_ARGS}'. Overwrite with ANSIBLE_ARGS"

--- a/tests/support/run-tests.sh
+++ b/tests/support/run-tests.sh
@@ -12,6 +12,11 @@ HELM_VERSION="${HELM_VERSION:-2.12.3}"
 ANSIBLE_ARGS="--diff ${ANSIBLE_ARGS:-}"
 
 
+# Prepare fake Helm value files
+mkdir -p ${test_directory}/helm-config/{prometheus,logstash}
+touch ${test_directory}/helm-config/prometheus/values.yml
+touch ${test_directory}/helm-config/logstash/values.yml
+
 
 echo "Ansible arguments set to '${ANSIBLE_ARGS}'. Overwrite with ANSIBLE_ARGS"
 
@@ -108,6 +113,10 @@ echo "--------------------------------------------------------------------------
 echo "- [NEED TO SUCC] (--check) Role with repositories defined"
 echo "----------------------------------------------------------------------------------------------------"
 ansible-playbook ${ANSIBLE_ARGS} ${test_directory}/test-with-repositories.yml --check
+
+
+# Clean up fake Helm value files
+rm -r "${test_directory}/helm-config"
 
 # Clean up
 rm -f /usr/local/bin/helm || true

--- a/tests/test-with-charts.yml
+++ b/tests/test-with-charts.yml
@@ -4,6 +4,7 @@
   roles:
     - role: rolename
       vars:
+        template_test_value: "templates are rendered"
         helm_charts:
           - release: prometheus
             chart: stable/prometheus
@@ -16,3 +17,9 @@
             chart_version: 8.8.0
             values_file_path: logstash/values.yml
             namespace: logstash
+
+          - release: test-template
+            chart: stable/test-template
+            chart_version: 8.8.0
+            values_file_path: test-template/values.yml.j2
+            namespace: test-template


### PR DESCRIPTION
All value files will be treated as Jinja2 templates.
They will be rendered into temporary files and then passed on to Helm.

**Example**

```
helm-config/logstash/values.yaml -[Jinja2 rendering]-> /tmp/ansible.FOUcmY -> run helm
```

So the Helm command will look like this:

```bash
helm install stable/logstash \
--dry-run \
--version 8.8.0 \
--namespace logstash \
--values /tmp/ansible.FOUcmY \
--name logstash
```

instead of:

```bash
helm install stable/logstash \
--dry-run \
--version 8.8.0 \
--namespace logstash \
--values helm-config/logstash/values.yaml \
--name logstash
```