### PR TITLE
OPS-0: New Location For Stable and Incubator Charts

### DIFF
--- a/library/parse_helm_repositories.py
+++ b/library/parse_helm_repositories.py
@@ -15,7 +15,7 @@ def parse_helm_repositories_output(text):
     reg = re.compile(r"^(?P<name>[^\s\t]+)[\s\t]+(?P<url>[^\s\n]+)$")
 
     # Loop through all the lines with the following format:
-    # stable             	https://kubernetes-charts.storage.googleapis.com
+    # stable             	https://charts.helm.sh/stable
     # local              	http://127.0.0.1:8879/charts
     for line in lines:
         match = reg.match(line)

--- a/library/test_parse_helm_repositories.py
+++ b/library/test_parse_helm_repositories.py
@@ -9,7 +9,7 @@ class parse(unittest.TestCase):
     def test_parse_helm_repositories_output(self):
         helm_repositories_output = """
 NAME               	URL
-stable             	https://kubernetes-charts.storage.googleapis.com
+stable             	https://charts.helm.sh/stable
 local              	http://127.0.0.1:8879/charts
 reactiveops-stable 	https://charts.reactiveops.com/stable
 flaconi-common-helm	s3://flaconi-helm-charts
@@ -19,7 +19,7 @@ zalenium-github    	https://raw.githubusercontent.com/zalando/zalenium/3.141.59u
         expected_helm_repositories = [
             {
                 "name": "stable",
-                "url": "https://kubernetes-charts.storage.googleapis.com",
+                "url": "https://charts.helm.sh/stable",
             },
             {
                 "name": "local",
@@ -45,7 +45,7 @@ zalenium-github    	https://raw.githubusercontent.com/zalando/zalenium/3.141.59u
     def test_parse_helm_repositories_output_malformed(self):
         helm_repositories_output = """
 NAME               	VERSION URL
-stable             	1       https://kubernetes-charts.storage.googleapis.com
+stable             	1       https://charts.helm.sh/stable
 local              	1       http://127.0.0.1:8879/charts
 reactiveops-stable 	1       https://charts.reactiveops.com/stable
 flaconi-common-helm	1       s3://flaconi-helm-charts

--- a/tasks/run.yml
+++ b/tasks/run.yml
@@ -6,7 +6,7 @@
       {% if helm_kubectl_context is defined and helm_kubectl_context %}
       --kube-context {{ helm_kubectl_context }}
       {% endif %}
-      elastic https://helm.elastic.co
+      stable https://charts.helm.sh/stable
   check_mode: False
 - name: Get Helm repositories
   command: |

--- a/tasks/run.yml
+++ b/tasks/run.yml
@@ -6,7 +6,7 @@
       {% if helm_kubectl_context is defined and helm_kubectl_context %}
       --kube-context {{ helm_kubectl_context }}
       {% endif %}
-      stable https://kubernetes-charts.storage.googleapis.com
+      elastic https://helm.elastic.co
   check_mode: False
 - name: Get Helm repositories
   command: |

--- a/tests/support/helm.mock
+++ b/tests/support/helm.mock
@@ -39,12 +39,12 @@ elif [ "${arguments}" = "repo add ${EXTRA_PARAMS}zalenium-github-existing https:
   exit 1
 elif [ "${arguments}" = "repo add ${EXTRA_PARAMS}zalenium-github-missing https://example.com/zalenium" ]; then
   exit 0
-elif [ "${arguments}" = "repo add ${EXTRA_PARAMS}stable https://kubernetes-charts.storage.googleapis.com" ]; then
+elif [ "${arguments}" = "repo add ${EXTRA_PARAMS}stable https://charts.helm.sh/stable" ]; then
   exit 0
 elif [ "${arguments} " = "repo list ${EXTRA_PARAMS}" ]; then
   cat << EOF
 NAME                        	URL
-stable                        https://kubernetes-charts.storage.googleapis.com
+stable                        https://charts.helm.sh/stable
 local                       	http://127.0.0.1:8879/charts
 reactiveops-stable          	https://charts.reactiveops.com/stable
 flaconi-common-helm         	s3://flaconi-helm-charts


### PR DESCRIPTION
## Reason
```
 helm repo add stable https://kubernetes-charts.storage.googleapis.com/                                         
 ```
 ```
Error: looks like "https://kubernetes-charts.storage.googleapis.com/" is not a valid chart repository or cannot be reached: failed to fetch https://kubernetes-charts.storage.googleapis.com/index.yaml : 403 Forbidden
```
**Note:** **New Location For Stable and Incubator Charts**
https://helm.sh/blog/new-location-stable-incubator-charts/


